### PR TITLE
BOM-1597 : Add Python 3.8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,20 @@ sudo: false
 language: python
 
 python:
-  - 3.7
-  - 3.6
   - 3.5
+  - 3.8
 
 env:
-  - TOX_ENV=django3
+  - TOX_ENV=django30
   - TOX_ENV=django22
-  - TOX_ENV=django21
-  - TOX_ENV=django20
-  - TOX_ENV=django111
 
 matrix:
   exclude:
     - python: 3.5
-      env: TOX_ENV=django3
+      env: TOX_ENV=django30
 
 before_install:
-  - "pip install -U pip"
+  - pip install pip==20.0.2
 
 install:
   - pip install tox

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,6 +2,6 @@
 
 -r github.in              # Github requirements
 
-django>=1.11
+django
 babel>=1.3
 markey>=0.8,<0.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 babel==2.8.0
 git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
-django==2.2.10
+django==2.2.12
 markey==0.8
-pytz==2019.3              # via babel, django
-sqlparse==0.3.0           # via django
+pytz==2020.1              # via babel, django
+sqlparse==0.3.1           # via django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,53 +8,53 @@ alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via execnet
 attrs==19.3.0             # via pytest
 babel==2.8.0
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-coverage==5.0.3
+coverage==5.1
 git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
-django==2.2.10
+django==2.2.12
 docutils==0.16            # via sphinx
 entrypoints==0.3          # via flake8
 execnet==1.7.1            # via pytest-cache
 flake8==3.7.9
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.5.0  # via pluggy, pytest
-jinja2==2.11.1            # via sphinx
+importlib-metadata==1.6.0  # via pluggy, pytest
+jinja2==2.11.2            # via sphinx
 markey==0.8
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 more-itertools==8.2.0     # via pytest
-packaging==20.1           # via pytest, sphinx
+packaging==20.3           # via pytest, sphinx
 pathlib2==2.3.5           # via pytest
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8, pytest-flakes
-pygments==2.5.2           # via sphinx
-pyparsing==2.4.6          # via packaging
+pygments==2.6.1           # via sphinx
+pyparsing==2.4.7          # via packaging
 pytest-cache==1.0         # via pytest-pep8
 pytest-cov==2.8.1
 pytest-flakes==4.0.0
 pytest-pep8==1.0.6
-pytest==5.3.5
+pytest==5.4.1
 python-coveralls==2.9.3
-pytz==2019.3              # via babel, django
-pyyaml==5.3               # via python-coveralls
+pytz==2020.1              # via babel, django
+pyyaml==5.3.1             # via python-coveralls
 requests==2.23.0          # via python-coveralls, sphinx
 six==1.14.0               # via packaging, pathlib2, python-coveralls
 snowballstemmer==2.0.0    # via sphinx
-sphinx==2.4.2
-sphinxcontrib-applehelp==1.0.1  # via sphinx
-sphinxcontrib-devhelp==1.0.1  # via sphinx
-sphinxcontrib-htmlhelp==1.0.2  # via sphinx
+sphinx==3.0.3
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-qthelp==1.0.2  # via sphinx
-sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-sqlparse==0.3.0           # via django
-urllib3==1.25.8           # via requests
-wcwidth==0.1.8            # via pytest
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+sqlparse==0.3.1           # via django
+urllib3==1.25.9           # via requests
+wcwidth==0.1.9            # via pytest
 zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,6 @@
 #
 #    make upgrade
 #
-click==7.0                # via pip-tools
-pip-tools==4.4.1
+click==7.1.2              # via pip-tools
+pip-tools==5.1.2
 six==1.14.0               # via pip-tools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,53 +8,53 @@ alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via execnet
 attrs==19.3.0             # via pytest
 babel==2.8.0
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-coverage==5.0.3
+coverage==5.1
 git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
-django==2.2.10
+django==2.2.12
 docutils==0.16            # via sphinx
 entrypoints==0.3          # via flake8
 execnet==1.7.1            # via pytest-cache
 flake8==3.7.9
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.5.0  # via pluggy, pytest
-jinja2==2.11.1            # via sphinx
+importlib-metadata==1.6.0  # via pluggy, pytest
+jinja2==2.11.2            # via sphinx
 markey==0.8
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 more-itertools==8.2.0     # via pytest
-packaging==20.1           # via pytest, sphinx
+packaging==20.3           # via pytest, sphinx
 pathlib2==2.3.5           # via pytest
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8, pytest-flakes
-pygments==2.5.2           # via sphinx
-pyparsing==2.4.6          # via packaging
+pygments==2.6.1           # via sphinx
+pyparsing==2.4.7          # via packaging
 pytest-cache==1.0         # via pytest-pep8
 pytest-cov==2.8.1
 pytest-flakes==4.0.0
 pytest-pep8==1.0.6
-pytest==5.3.5
+pytest==5.4.1
 python-coveralls==2.9.3
-pytz==2019.3              # via babel, django
-pyyaml==5.3               # via python-coveralls
+pytz==2020.1              # via babel, django
+pyyaml==5.3.1             # via python-coveralls
 requests==2.23.0          # via python-coveralls, sphinx
 six==1.14.0               # via packaging, pathlib2, python-coveralls
 snowballstemmer==2.0.0    # via sphinx
-sphinx==2.4.2
-sphinxcontrib-applehelp==1.0.1  # via sphinx
-sphinxcontrib-devhelp==1.0.1  # via sphinx
-sphinxcontrib-htmlhelp==1.0.2  # via sphinx
+sphinx==3.0.3
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-qthelp==1.0.2  # via sphinx
-sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-sqlparse==0.3.0           # via django
-urllib3==1.25.8           # via requests
-wcwidth==0.1.8            # via pytest
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+sqlparse==0.3.1           # via django
+urllib3==1.25.9           # via requests
+wcwidth==0.1.9            # via pytest
 zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -8,9 +8,9 @@ alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via execnet
 attrs==19.3.0             # via pytest
 babel==2.8.0
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-coverage==5.0.3
+coverage==5.1
 git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
 docutils==0.16            # via sphinx
 entrypoints==0.3          # via flake8
@@ -18,42 +18,42 @@ execnet==1.7.1            # via pytest-cache
 flake8==3.7.9
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.5.0  # via pluggy, pytest
-jinja2==2.11.1            # via sphinx
+importlib-metadata==1.6.0  # via pluggy, pytest
+jinja2==2.11.2            # via sphinx
 markey==0.8
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 more-itertools==8.2.0     # via pytest
-packaging==20.1           # via pytest, sphinx
+packaging==20.3           # via pytest, sphinx
 pathlib2==2.3.5           # via pytest
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8, pytest-flakes
-pygments==2.5.2           # via sphinx
-pyparsing==2.4.6          # via packaging
+pygments==2.6.1           # via sphinx
+pyparsing==2.4.7          # via packaging
 pytest-cache==1.0         # via pytest-pep8
 pytest-cov==2.8.1
 pytest-flakes==4.0.0
 pytest-pep8==1.0.6
-pytest==5.3.5
+pytest==5.4.1
 python-coveralls==2.9.3
-pytz==2019.3              # via babel, django
-pyyaml==5.3               # via python-coveralls
+pytz==2020.1              # via babel, django
+pyyaml==5.3.1             # via python-coveralls
 requests==2.23.0          # via python-coveralls, sphinx
 six==1.14.0               # via packaging, pathlib2, python-coveralls
 snowballstemmer==2.0.0    # via sphinx
-sphinx==2.4.2
-sphinxcontrib-applehelp==1.0.1  # via sphinx
-sphinxcontrib-devhelp==1.0.1  # via sphinx
-sphinxcontrib-htmlhelp==1.0.2  # via sphinx
+sphinx==3.0.3
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-qthelp==1.0.2  # via sphinx
-sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-sqlparse==0.3.0           # via django
-urllib3==1.25.8           # via requests
-wcwidth==0.1.8            # via pytest
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+sqlparse==0.3.1           # via django
+urllib3==1.25.9           # via requests
+wcwidth==0.1.9            # via pytest
 zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import codecs
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-version = '0.6.0'
+version = '0.6.1'
 
 
 def read(*parts):
@@ -85,10 +85,8 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.2',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,13 @@
 [tox]
-envlist = py{35,36,37}-django{111,20,21,22}, py{36,37}-django3
+envlist = py35-django22, py38-django{22,30}
 
 [testenv]
 skipsdist = True
 usedevelop = True
 deps =
     -r{toxinidir}/requirements/tox.txt
-    django111: Django>=1.11,<2
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
-    django3: Django>=3,<4
+    django30: Django>=3.0,<3.1
     -e.
 commands =
     python -Wd -m pytest {posargs}


### PR DESCRIPTION
- Added Python 3.8 support
- Removed Python versions other than 3.5 and 3.8
- Upgraded dependecies
- Updated classifiers and bumped version

Relevant JIRA : https://openedx.atlassian.net/browse/BOM-1597