### PR TITLE
Using enmerkar latest ver instead of commit hash.

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,6 +2,7 @@
 
 -r github.in              # Github requirements
 
-django
+django<2.3
 babel>=1.3
 markey>=0.8,<0.9
+enmerkar

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-babel==2.8.0
-git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
-django==2.2.12
-markey==0.8
+babel==2.8.0              # via -r requirements/base.in, enmerkar
+django==2.2.12            # via -r requirements/base.in, enmerkar
+enmerkar==0.7.1           # via -r requirements/base.in
+markey==0.8               # via -r requirements/base.in
 pytz==2020.1              # via babel, django
 sqlparse==0.3.1           # via django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,45 +7,44 @@
 alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via execnet
 attrs==19.3.0             # via pytest
-babel==2.8.0
+babel==2.8.0              # via -r requirements/base.in, enmerkar, sphinx
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-coverage==5.1
-git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
-django==2.2.12
+coverage==5.1             # via -r requirements/test.in, pytest-cov, python-coveralls
+django==2.2.12            # via -r requirements/base.in, enmerkar
 docutils==0.16            # via sphinx
-entrypoints==0.3          # via flake8
+enmerkar==0.7.1           # via -r requirements/base.in
 execnet==1.7.1            # via pytest-cache
-flake8==3.7.9
+flake8==3.8.1             # via -r requirements/test.in
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.0  # via pluggy, pytest
+importlib-metadata==1.6.0  # via flake8, pluggy, pytest
 jinja2==2.11.2            # via sphinx
-markey==0.8
+markey==0.8               # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
-more-itertools==8.2.0     # via pytest
-packaging==20.3           # via pytest, sphinx
+more-itertools==8.3.0     # via pytest
+packaging==20.4           # via pytest, sphinx
 pathlib2==2.3.5           # via pytest
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8, pytest-flakes
+pycodestyle==2.6.0        # via flake8
+pyflakes==2.2.0           # via flake8, pytest-flakes
 pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytest-cache==1.0         # via pytest-pep8
-pytest-cov==2.8.1
-pytest-flakes==4.0.0
-pytest-pep8==1.0.6
-pytest==5.4.1
-python-coveralls==2.9.3
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-flakes==4.0.0      # via -r requirements/test.in
+pytest-pep8==1.0.6        # via -r requirements/test.in
+pytest==5.4.2             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-flakes, pytest-pep8
+python-coveralls==2.9.3   # via -r requirements/test.in
 pytz==2020.1              # via babel, django
 pyyaml==5.3.1             # via python-coveralls
 requests==2.23.0          # via python-coveralls, sphinx
-six==1.14.0               # via packaging, pathlib2, python-coveralls
+six==1.15.0               # via packaging, pathlib2, python-coveralls
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.0.3
+sphinx==3.0.3             # via -r requirements/test.in
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/github.in
+++ b/requirements/github.in
@@ -1,2 +1,0 @@
-# As latest version of enmerkar does not support old versions of django<2.2
-git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,8 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.1.2
-six==1.14.0               # via pip-tools
+pip-tools==5.1.2          # via -r requirements/pip-tools.in
+six==1.15.0               # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,45 +7,44 @@
 alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via execnet
 attrs==19.3.0             # via pytest
-babel==2.8.0
+babel==2.8.0              # via -r requirements/base.in, enmerkar, sphinx
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-coverage==5.1
-git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
-django==2.2.12
+coverage==5.1             # via -r requirements/test.in, pytest-cov, python-coveralls
+django==2.2.12            # via -r requirements/base.in, enmerkar
 docutils==0.16            # via sphinx
-entrypoints==0.3          # via flake8
+enmerkar==0.7.1           # via -r requirements/base.in
 execnet==1.7.1            # via pytest-cache
-flake8==3.7.9
+flake8==3.8.1             # via -r requirements/test.in
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.0  # via pluggy, pytest
+importlib-metadata==1.6.0  # via flake8, pluggy, pytest
 jinja2==2.11.2            # via sphinx
-markey==0.8
+markey==0.8               # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
-more-itertools==8.2.0     # via pytest
-packaging==20.3           # via pytest, sphinx
+more-itertools==8.3.0     # via pytest
+packaging==20.4           # via pytest, sphinx
 pathlib2==2.3.5           # via pytest
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8, pytest-flakes
+pycodestyle==2.6.0        # via flake8
+pyflakes==2.2.0           # via flake8, pytest-flakes
 pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytest-cache==1.0         # via pytest-pep8
-pytest-cov==2.8.1
-pytest-flakes==4.0.0
-pytest-pep8==1.0.6
-pytest==5.4.1
-python-coveralls==2.9.3
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-flakes==4.0.0      # via -r requirements/test.in
+pytest-pep8==1.0.6        # via -r requirements/test.in
+pytest==5.4.2             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-flakes, pytest-pep8
+python-coveralls==2.9.3   # via -r requirements/test.in
 pytz==2020.1              # via babel, django
 pyyaml==5.3.1             # via python-coveralls
 requests==2.23.0          # via python-coveralls, sphinx
-six==1.14.0               # via packaging, pathlib2, python-coveralls
+six==1.15.0               # via packaging, pathlib2, python-coveralls
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.0.3
+sphinx==3.0.3             # via -r requirements/test.in
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -7,44 +7,43 @@
 alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via execnet
 attrs==19.3.0             # via pytest
-babel==2.8.0
+babel==2.8.0              # via -r requirements/base.in, enmerkar, sphinx
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-coverage==5.1
-git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
+coverage==5.1             # via -r requirements/test.in, pytest-cov, python-coveralls
 docutils==0.16            # via sphinx
-entrypoints==0.3          # via flake8
+enmerkar==0.7.1           # via -r requirements/base.in
 execnet==1.7.1            # via pytest-cache
-flake8==3.7.9
+flake8==3.8.1             # via -r requirements/test.in
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.0  # via pluggy, pytest
+importlib-metadata==1.6.0  # via flake8, pluggy, pytest
 jinja2==2.11.2            # via sphinx
-markey==0.8
+markey==0.8               # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
-more-itertools==8.2.0     # via pytest
-packaging==20.3           # via pytest, sphinx
+more-itertools==8.3.0     # via pytest
+packaging==20.4           # via pytest, sphinx
 pathlib2==2.3.5           # via pytest
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8, pytest-flakes
+pycodestyle==2.6.0        # via flake8
+pyflakes==2.2.0           # via flake8, pytest-flakes
 pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytest-cache==1.0         # via pytest-pep8
-pytest-cov==2.8.1
-pytest-flakes==4.0.0
-pytest-pep8==1.0.6
-pytest==5.4.1
-python-coveralls==2.9.3
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-flakes==4.0.0      # via -r requirements/test.in
+pytest-pep8==1.0.6        # via -r requirements/test.in
+pytest==5.4.2             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-flakes, pytest-pep8
+python-coveralls==2.9.3   # via -r requirements/test.in
 pytz==2020.1              # via babel, django
 pyyaml==5.3.1             # via python-coveralls
 requests==2.23.0          # via python-coveralls, sphinx
-six==1.14.0               # via packaging, pathlib2, python-coveralls
+six==1.15.0               # via packaging, pathlib2, python-coveralls
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.0.3
+sphinx==3.0.3             # via -r requirements/test.in
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/src/django_babel_underscore/__init__.py
+++ b/src/django_babel_underscore/__init__.py
@@ -12,7 +12,7 @@ else:  # django < 2.1
     from django.template.base import TOKEN_TEXT
 
 from django.utils.encoding import force_text
-from django_babel.extract import extract_django
+from enmerkar.extract import extract_django
 from markey import underscore
 from markey.tools import TokenStream
 from markey.machine import tokenize, parse_arguments

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,47 +1,220 @@
 # -*- coding: utf-8 -*-
+import unittest
+
 import pytest
+
+from babel.messages import extract
 from babel._compat import BytesIO
 
-from django_babel_underscore import extract
+import django
+from enmerkar.extract import extract_django
 
 
-class TestMixedExtract:
+default_keys = extract.DEFAULT_KEYWORDS.keys()
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.keywords = extract.DEFAULT_KEYWORDS.keys()
 
-    def test_parses_django(self):
+class ExtractDjangoTestCase(unittest.TestCase):
+    # TODO: translator comments are not yet supported!
+
+    def test_extract_no_tags(self):
+        buf = BytesIO(b'nothing')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([], messages)
+
+    def test_extract_simple_double_quotes(self):
         buf = BytesIO(b'{% trans "Bunny" %}')
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == ([(1, None, u'Bunny', [])])
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'Bunny', [])], messages)
 
-    def test_parses_blocktrans(self):
-        buf = BytesIO(b'Ignored {% blocktrans %}{{ anton }}{% endblocktrans %}')
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == [(1, None, u'%(anton)s', [])]
+    def test_extract_simple_single_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'Bunny', [])], messages)
 
-    def test_parses_underscore(self):
-        buf = BytesIO(b'hello: <%= name %>')
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == []
+    def test_extract_simple_with_context_single_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' context 'carrot' %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, 'pgettext',
+                           [u'carrot', u'Bunny'], [])], messages)
 
-    def test_parses_underscore_gettext(self):
-        buf = BytesIO(b'hello: <%= gettext("name") %>')
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == [(1, 'gettext', u'name', [])]
+    def test_extract_simple_with_context_double_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' context \"carrot\" %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, 'pgettext',
+                           [u'carrot', u'Bunny'], [])], messages)
+
+    def test_extract_simple_with_context_with_single_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' context \"'carrot'\" %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, 'pgettext',
+                           [u'\'carrot\'', u'Bunny'], [])], messages)
+
+    def test_extract_simple_with_context_with_double_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' context '\"carrot\"' %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, 'pgettext',
+                           [u'"carrot"', u'Bunny'], [])], messages)
+
+    def test_extract_var(self):
+        buf = BytesIO(b'{% blocktrans %}{{ anton }}{% endblocktrans %}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'%(anton)s', [])], messages)
+
+    def test_extract_filter_with_filter(self):
+        test_tmpl = (
+            b'{% blocktrans with berta=anton|lower %}'
+            b'{{ berta }}{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'%(berta)s', [])], messages)
+
+    def test_extract_with_interpolation(self):
+        buf = BytesIO(b'{% blocktrans %}xxx{{ anton }}xxx{% endblocktrans %}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'xxx%(anton)sxxx', [])], messages)
 
     def test_extract_unicode(self):
-        buf = BytesIO(u'<%= gettext("@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ") %>'.encode('utf-8'))
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == [(1, 'gettext', u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])]
+        buf = BytesIO(u'{% trans "@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ" %}'.encode('utf8'))
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])], messages)
+
+    def test_extract_unicode_blocktrans(self):
+        test_tmpl = u'{% blocktrans %}@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ{% endblocktrans %}'
+        buf = BytesIO(test_tmpl.encode('utf8'))
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])], messages)
+
+    # TODO: Yet expected to not extract the comments.
+    def test_extract_ignored_comment(self):
+        buf = BytesIO(
+            b'{# ignored comment #1 #}{% trans "Translatable literal #9a" %}',
+        )
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, None, u'Translatable literal #9a', [])], messages
+        )
+
+    def test_extract_ignored_comment2(self):
+        test_tmpl = (
+            b'{# Translators: ignored i18n comment #1 #}'
+            b'{% trans "Translatable literal #9a" %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, None, u'Translatable literal #9a', [])], messages
+        )
+
+    def test_extract_valid_comment(self):
+        test_tmpl = (
+            b'{# ignored comment #6 #}'
+            b'{% trans "Translatable literal #9h" %}'
+            b'{# Translators: valid i18n comment #7 #}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, None, u'Translatable literal #9h', [])], messages
+        )
 
     def test_extract_singular_form(self):
-        buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", 42) %>')
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None), [])]  # noqa
+        test_tmpl = (
+            b'{% blocktrans count counter=number %}'
+            b'singular{% plural %}{{ counter }} plural'
+            b'{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, 'ngettext', (u'singular', u'%(counter)s plural'), [])],
+            messages
+        )
 
-    def test_extract_singular_form_kwargs(self):
-        buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", count=42) %>')
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None, u'count'), [])]  # noqa#
+    def test_trans_blocks_must_not_include_other_block_tags(self):
+        buf = BytesIO(b'{% blocktrans %}{% other_tag %}{% endblocktrans %}')
+        gen = extract_django(buf, default_keys, [], {})
+        with pytest.raises(SyntaxError):
+            next(gen)
+
+    def test_extract_var_other(self):
+        buf = BytesIO(b'{{ book }}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([], messages)
+
+    def test_extract_filters_default_translatable(self):
+        buf = BytesIO(b'{{ book.author|default:_("Unknown") }}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'Unknown', [])], messages)
+
+    def test_extract_filters_default_translatable_single_quotes(self):
+        buf = BytesIO(b"{{ book.author|default:_('Unknown') }}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'Unknown', [])], messages)
+
+    def test_extract_constant_single_quotes(self):
+        buf = BytesIO(b"{{ _('constant') }}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'constant', [])], messages)
+
+    def test_extract_constant_double_quotes(self):
+        buf = BytesIO(b'{{ _("constant") }}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'constant', [])], messages)
+
+    def test_extract_constant_block(self):
+        buf = BytesIO(b'{% _("constant") %}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'constant', [])], messages)
+
+    def test_extract_constant_in_block(self):
+        test_tmpl = (
+            b'{% blocktrans foo=_("constant") %}{{ foo }}{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, None, u'constant', []), (1, None, u'%(foo)s', [])],
+            messages,
+        )
+
+    def test_extract_context_in_block(self):
+        test_tmpl = (
+            b'{% blocktrans context "banana" %}{{ foo }}{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, 'pgettext', [u'banana', u'%(foo)s'], [])],
+            messages,
+        )
+
+    def test_extract_context_in_plural_block(self):
+        test_tmpl = (
+            b'{% blocktrans context "banana" %}{{ foo }}'
+            b'{% plural %}{{ bar }}{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, 'npgettext', [u'banana', u'%(foo)s', u'%(bar)s'], [])],
+            messages,
+        )
+
+    def test_blocktrans_with_whitespace_not_trimmed(self):
+        test_tmpl = (
+            b'{% blocktrans %}\n\tfoo\n\tbar\n{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(4, None, u'\n\tfoo\n\tbar\n', [])], messages)
+
+    @pytest.mark.skipif(django.VERSION < (1, 7),
+                        reason='Trimmed whitespace is a Django >= 1.7 feature')
+    def test_blocktrans_with_whitespace_trimmed(self):
+        test_tmpl = (
+            b'{% blocktrans trimmed %}\n\tfoo\n\tbar\n{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(4, None, u'foo bar', [])], messages)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,220 +1,48 @@
 # -*- coding: utf-8 -*-
-import unittest
-
 import pytest
-
-from babel.messages import extract
 from babel._compat import BytesIO
+from babel.messages.extract import DEFAULT_KEYWORDS
 
-import django
-from enmerkar.extract import extract_django
-
-
-default_keys = extract.DEFAULT_KEYWORDS.keys()
+from enmerkar.extract import extract_django as extract
 
 
-class ExtractDjangoTestCase(unittest.TestCase):
-    # TODO: translator comments are not yet supported!
+class TestMixedExtract:
 
-    def test_extract_no_tags(self):
-        buf = BytesIO(b'nothing')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([], messages)
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.keywords = DEFAULT_KEYWORDS.keys()
 
-    def test_extract_simple_double_quotes(self):
+    def test_parses_django(self):
         buf = BytesIO(b'{% trans "Bunny" %}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'Bunny', [])], messages)
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == ([(1, None, u'Bunny', [])])
 
-    def test_extract_simple_single_quotes(self):
-        buf = BytesIO(b"{% trans 'Bunny' %}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'Bunny', [])], messages)
+    def test_parses_blocktrans(self):
+        buf = BytesIO(b'Ignored {% blocktrans %}{{ anton }}{% endblocktrans %}')
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == [(1, None, u'%(anton)s', [])]
 
-    def test_extract_simple_with_context_single_quotes(self):
-        buf = BytesIO(b"{% trans 'Bunny' context 'carrot' %}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, 'pgettext',
-                           [u'carrot', u'Bunny'], [])], messages)
+    def test_parses_underscore(self):
+        buf = BytesIO(b'hello: <%= name %>')
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == []
 
-    def test_extract_simple_with_context_double_quotes(self):
-        buf = BytesIO(b"{% trans 'Bunny' context \"carrot\" %}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, 'pgettext',
-                           [u'carrot', u'Bunny'], [])], messages)
-
-    def test_extract_simple_with_context_with_single_quotes(self):
-        buf = BytesIO(b"{% trans 'Bunny' context \"'carrot'\" %}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, 'pgettext',
-                           [u'\'carrot\'', u'Bunny'], [])], messages)
-
-    def test_extract_simple_with_context_with_double_quotes(self):
-        buf = BytesIO(b"{% trans 'Bunny' context '\"carrot\"' %}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, 'pgettext',
-                           [u'"carrot"', u'Bunny'], [])], messages)
-
-    def test_extract_var(self):
-        buf = BytesIO(b'{% blocktrans %}{{ anton }}{% endblocktrans %}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'%(anton)s', [])], messages)
-
-    def test_extract_filter_with_filter(self):
-        test_tmpl = (
-            b'{% blocktrans with berta=anton|lower %}'
-            b'{{ berta }}{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'%(berta)s', [])], messages)
-
-    def test_extract_with_interpolation(self):
-        buf = BytesIO(b'{% blocktrans %}xxx{{ anton }}xxx{% endblocktrans %}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'xxx%(anton)sxxx', [])], messages)
+    def test_parses_underscore_gettext(self):
+        buf = BytesIO(b'hello: <%= gettext("name") %>')
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == [(1, 'gettext', u'name', [])]
 
     def test_extract_unicode(self):
-        buf = BytesIO(u'{% trans "@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ" %}'.encode('utf8'))
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])], messages)
-
-    def test_extract_unicode_blocktrans(self):
-        test_tmpl = u'{% blocktrans %}@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ{% endblocktrans %}'
-        buf = BytesIO(test_tmpl.encode('utf8'))
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])], messages)
-
-    # TODO: Yet expected to not extract the comments.
-    def test_extract_ignored_comment(self):
-        buf = BytesIO(
-            b'{# ignored comment #1 #}{% trans "Translatable literal #9a" %}',
-        )
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, None, u'Translatable literal #9a', [])], messages
-        )
-
-    def test_extract_ignored_comment2(self):
-        test_tmpl = (
-            b'{# Translators: ignored i18n comment #1 #}'
-            b'{% trans "Translatable literal #9a" %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, None, u'Translatable literal #9a', [])], messages
-        )
-
-    def test_extract_valid_comment(self):
-        test_tmpl = (
-            b'{# ignored comment #6 #}'
-            b'{% trans "Translatable literal #9h" %}'
-            b'{# Translators: valid i18n comment #7 #}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, None, u'Translatable literal #9h', [])], messages
-        )
+        buf = BytesIO(u'<%= gettext("@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ") %>'.encode('utf-8'))
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == [(1, 'gettext', u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])]
 
     def test_extract_singular_form(self):
-        test_tmpl = (
-            b'{% blocktrans count counter=number %}'
-            b'singular{% plural %}{{ counter }} plural'
-            b'{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, 'ngettext', (u'singular', u'%(counter)s plural'), [])],
-            messages
-        )
+        buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", 42) %>')
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None), [])]  # noqa
 
-    def test_trans_blocks_must_not_include_other_block_tags(self):
-        buf = BytesIO(b'{% blocktrans %}{% other_tag %}{% endblocktrans %}')
-        gen = extract_django(buf, default_keys, [], {})
-        with pytest.raises(SyntaxError):
-            next(gen)
-
-    def test_extract_var_other(self):
-        buf = BytesIO(b'{{ book }}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([], messages)
-
-    def test_extract_filters_default_translatable(self):
-        buf = BytesIO(b'{{ book.author|default:_("Unknown") }}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'Unknown', [])], messages)
-
-    def test_extract_filters_default_translatable_single_quotes(self):
-        buf = BytesIO(b"{{ book.author|default:_('Unknown') }}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'Unknown', [])], messages)
-
-    def test_extract_constant_single_quotes(self):
-        buf = BytesIO(b"{{ _('constant') }}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'constant', [])], messages)
-
-    def test_extract_constant_double_quotes(self):
-        buf = BytesIO(b'{{ _("constant") }}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'constant', [])], messages)
-
-    def test_extract_constant_block(self):
-        buf = BytesIO(b'{% _("constant") %}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'constant', [])], messages)
-
-    def test_extract_constant_in_block(self):
-        test_tmpl = (
-            b'{% blocktrans foo=_("constant") %}{{ foo }}{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, None, u'constant', []), (1, None, u'%(foo)s', [])],
-            messages,
-        )
-
-    def test_extract_context_in_block(self):
-        test_tmpl = (
-            b'{% blocktrans context "banana" %}{{ foo }}{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, 'pgettext', [u'banana', u'%(foo)s'], [])],
-            messages,
-        )
-
-    def test_extract_context_in_plural_block(self):
-        test_tmpl = (
-            b'{% blocktrans context "banana" %}{{ foo }}'
-            b'{% plural %}{{ bar }}{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, 'npgettext', [u'banana', u'%(foo)s', u'%(bar)s'], [])],
-            messages,
-        )
-
-    def test_blocktrans_with_whitespace_not_trimmed(self):
-        test_tmpl = (
-            b'{% blocktrans %}\n\tfoo\n\tbar\n{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(4, None, u'\n\tfoo\n\tbar\n', [])], messages)
-
-    @pytest.mark.skipif(django.VERSION < (1, 7),
-                        reason='Trimmed whitespace is a Django >= 1.7 feature')
-    def test_blocktrans_with_whitespace_trimmed(self):
-        test_tmpl = (
-            b'{% blocktrans trimmed %}\n\tfoo\n\tbar\n{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(4, None, u'foo bar', [])], messages)
+    def test_extract_singular_form_kwargs(self):
+        buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", count=42) %>')
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None, None), [])]  # noqa

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@ import pytest
 from babel._compat import BytesIO
 from babel.messages.extract import DEFAULT_KEYWORDS
 
-from enmerkar.extract import extract_django as extract
+from enmerkar.extract import extract_django
 
 
 class TestMixedExtract:
@@ -14,35 +14,35 @@ class TestMixedExtract:
 
     def test_parses_django(self):
         buf = BytesIO(b'{% trans "Bunny" %}')
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == ([(1, None, u'Bunny', [])])
 
     def test_parses_blocktrans(self):
         buf = BytesIO(b'Ignored {% blocktrans %}{{ anton }}{% endblocktrans %}')
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == [(1, None, u'%(anton)s', [])]
 
     def test_parses_underscore(self):
         buf = BytesIO(b'hello: <%= name %>')
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == []
 
     def test_parses_underscore_gettext(self):
         buf = BytesIO(b'hello: <%= gettext("name") %>')
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == [(1, 'gettext', u'name', [])]
 
     def test_extract_unicode(self):
         buf = BytesIO(u'<%= gettext("@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ") %>'.encode('utf-8'))
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == [(1, 'gettext', u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])]
 
     def test_extract_singular_form(self):
         buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", 42) %>')
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None), [])]  # noqa
 
     def test_extract_singular_form_kwargs(self):
         buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", count=42) %>')
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None, None), [])]  # noqa

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,220 +1,48 @@
 # -*- coding: utf-8 -*-
-import unittest
-
 import pytest
-
-from babel.messages import extract
 from babel._compat import BytesIO
+from babel.messages.extract import DEFAULT_KEYWORDS
 
-import django
-from enmerkar.extract import extract_django
-
-
-default_keys = extract.DEFAULT_KEYWORDS.keys()
+from enmerkar.extract import extract_django as extract
 
 
-class ExtractDjangoTestCase(unittest.TestCase):
-    # TODO: translator comments are not yet supported!
+class TestMixedExtract:
 
-    def test_extract_no_tags(self):
-        buf = BytesIO(b'nothing')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([], messages)
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.keywords = DEFAULT_KEYWORDS.keys()
 
-    def test_extract_simple_double_quotes(self):
+    def test_parses_django(self):
         buf = BytesIO(b'{% trans "Bunny" %}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'Bunny', [])], messages)
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == ([(1, None, u'Bunny', [])])
 
-    def test_extract_simple_single_quotes(self):
-        buf = BytesIO(b"{% trans 'Bunny' %}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'Bunny', [])], messages)
+    def test_parses_blocktrans(self):
+        buf = BytesIO(b'Ignored {% blocktrans %}{{ anton }}{% endblocktrans %}')
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == [(1, None, u'%(anton)s', [])]
 
-    def test_extract_simple_with_context_single_quotes(self):
-        buf = BytesIO(b"{% trans 'Bunny' context 'carrot' %}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, 'pgettext',
-                           [u'carrot', u'Bunny'], [])], messages)
+    def test_parses_underscore(self):
+        buf = BytesIO(b'hello: <%= name %>')
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == []
 
-    def test_extract_simple_with_context_double_quotes(self):
-        buf = BytesIO(b"{% trans 'Bunny' context \"carrot\" %}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, 'pgettext',
-                           [u'carrot', u'Bunny'], [])], messages)
-
-    def test_extract_simple_with_context_with_single_quotes(self):
-        buf = BytesIO(b"{% trans 'Bunny' context \"'carrot'\" %}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, 'pgettext',
-                           [u'\'carrot\'', u'Bunny'], [])], messages)
-
-    def test_extract_simple_with_context_with_double_quotes(self):
-        buf = BytesIO(b"{% trans 'Bunny' context '\"carrot\"' %}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, 'pgettext',
-                           [u'"carrot"', u'Bunny'], [])], messages)
-
-    def test_extract_var(self):
-        buf = BytesIO(b'{% blocktrans %}{{ anton }}{% endblocktrans %}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'%(anton)s', [])], messages)
-
-    def test_extract_filter_with_filter(self):
-        test_tmpl = (
-            b'{% blocktrans with berta=anton|lower %}'
-            b'{{ berta }}{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'%(berta)s', [])], messages)
-
-    def test_extract_with_interpolation(self):
-        buf = BytesIO(b'{% blocktrans %}xxx{{ anton }}xxx{% endblocktrans %}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'xxx%(anton)sxxx', [])], messages)
+    def test_parses_underscore_gettext(self):
+        buf = BytesIO(b'hello: <%= gettext("name") %>')
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == [(1, 'gettext', u'name', [])]
 
     def test_extract_unicode(self):
-        buf = BytesIO(u'{% trans "@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ" %}'.encode('utf8'))
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])], messages)
-
-    def test_extract_unicode_blocktrans(self):
-        test_tmpl = u'{% blocktrans %}@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ{% endblocktrans %}'
-        buf = BytesIO(test_tmpl.encode('utf8'))
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])], messages)
-
-    # TODO: Yet expected to not extract the comments.
-    def test_extract_ignored_comment(self):
-        buf = BytesIO(
-            b'{# ignored comment #1 #}{% trans "Translatable literal #9a" %}',
-        )
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, None, u'Translatable literal #9a', [])], messages
-        )
-
-    def test_extract_ignored_comment2(self):
-        test_tmpl = (
-            b'{# Translators: ignored i18n comment #1 #}'
-            b'{% trans "Translatable literal #9a" %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, None, u'Translatable literal #9a', [])], messages
-        )
-
-    def test_extract_valid_comment(self):
-        test_tmpl = (
-            b'{# ignored comment #6 #}'
-            b'{% trans "Translatable literal #9h" %}'
-            b'{# Translators: valid i18n comment #7 #}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, None, u'Translatable literal #9h', [])], messages
-        )
+        buf = BytesIO(u'<%= gettext("@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ") %>'.encode('utf-8'))
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == [(1, 'gettext', u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])]
 
     def test_extract_singular_form(self):
-        test_tmpl = (
-            b'{% blocktrans count counter=number %}'
-            b'singular{% plural %}{{ counter }} plural'
-            b'{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, 'ngettext', (u'singular', u'%(counter)s plural'), [])],
-            messages
-        )
+        buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", 42) %>')
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None), [])]  # noqa
 
-    def test_trans_blocks_must_not_include_other_block_tags(self):
-        buf = BytesIO(b'{% blocktrans %}{% other_tag %}{% endblocktrans %}')
-        gen = extract_django(buf, default_keys, [], {})
-        with pytest.raises(SyntaxError):
-            next(gen)
-
-    def test_extract_var_other(self):
-        buf = BytesIO(b'{{ book }}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([], messages)
-
-    def test_extract_filters_default_translatable(self):
-        buf = BytesIO(b'{{ book.author|default:_("Unknown") }}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'Unknown', [])], messages)
-
-    def test_extract_filters_default_translatable_single_quotes(self):
-        buf = BytesIO(b"{{ book.author|default:_('Unknown') }}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'Unknown', [])], messages)
-
-    def test_extract_constant_single_quotes(self):
-        buf = BytesIO(b"{{ _('constant') }}")
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'constant', [])], messages)
-
-    def test_extract_constant_double_quotes(self):
-        buf = BytesIO(b'{{ _("constant") }}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'constant', [])], messages)
-
-    def test_extract_constant_block(self):
-        buf = BytesIO(b'{% _("constant") %}')
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'constant', [])], messages)
-
-    def test_extract_constant_in_block(self):
-        test_tmpl = (
-            b'{% blocktrans foo=_("constant") %}{{ foo }}{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, None, u'constant', []), (1, None, u'%(foo)s', [])],
-            messages,
-        )
-
-    def test_extract_context_in_block(self):
-        test_tmpl = (
-            b'{% blocktrans context "banana" %}{{ foo }}{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, 'pgettext', [u'banana', u'%(foo)s'], [])],
-            messages,
-        )
-
-    def test_extract_context_in_plural_block(self):
-        test_tmpl = (
-            b'{% blocktrans context "banana" %}{{ foo }}'
-            b'{% plural %}{{ bar }}{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual(
-            [(1, 'npgettext', [u'banana', u'%(foo)s', u'%(bar)s'], [])],
-            messages,
-        )
-
-    def test_blocktrans_with_whitespace_not_trimmed(self):
-        test_tmpl = (
-            b'{% blocktrans %}\n\tfoo\n\tbar\n{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(4, None, u'\n\tfoo\n\tbar\n', [])], messages)
-
-    @pytest.mark.skipif(django.VERSION < (1, 7),
-                        reason='Trimmed whitespace is a Django >= 1.7 feature')
-    def test_blocktrans_with_whitespace_trimmed(self):
-        test_tmpl = (
-            b'{% blocktrans trimmed %}\n\tfoo\n\tbar\n{% endblocktrans %}'
-        )
-        buf = BytesIO(test_tmpl)
-        messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(4, None, u'foo bar', [])], messages)
+    def test_extract_singular_form_kwargs(self):
+        buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", count=42) %>')
+        messages = list(extract(buf, self.keywords, [], {}))
+        assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None, None), [])]  # noqa

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -3,7 +3,7 @@ import pytest
 from babel._compat import BytesIO
 from babel.messages.extract import DEFAULT_KEYWORDS
 
-from enmerkar.extract import extract_django as extract
+from enmerkar.extract import extract_django
 
 
 class TestMixedExtract:
@@ -14,35 +14,35 @@ class TestMixedExtract:
 
     def test_parses_django(self):
         buf = BytesIO(b'{% trans "Bunny" %}')
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == ([(1, None, u'Bunny', [])])
 
     def test_parses_blocktrans(self):
         buf = BytesIO(b'Ignored {% blocktrans %}{{ anton }}{% endblocktrans %}')
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == [(1, None, u'%(anton)s', [])]
 
     def test_parses_underscore(self):
         buf = BytesIO(b'hello: <%= name %>')
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == []
 
     def test_parses_underscore_gettext(self):
         buf = BytesIO(b'hello: <%= gettext("name") %>')
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == [(1, 'gettext', u'name', [])]
 
     def test_extract_unicode(self):
         buf = BytesIO(u'<%= gettext("@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ") %>'.encode('utf-8'))
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == [(1, 'gettext', u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])]
 
     def test_extract_singular_form(self):
         buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", 42) %>')
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None), [])]  # noqa
 
     def test_extract_singular_form_kwargs(self):
         buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", count=42) %>')
-        messages = list(extract(buf, self.keywords, [], {}))
+        messages = list(extract_django(buf, self.keywords, [], {}))
         assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None, None), [])]  # noqa

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,48 +1,220 @@
 # -*- coding: utf-8 -*-
+import unittest
+
 import pytest
+
+from babel.messages import extract
 from babel._compat import BytesIO
-from babel.messages.extract import DEFAULT_KEYWORDS
 
-from django_babel_underscore import extract
+import django
+from enmerkar.extract import extract_django
 
 
-class TestMixedExtract:
+default_keys = extract.DEFAULT_KEYWORDS.keys()
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.keywords = DEFAULT_KEYWORDS.keys()
 
-    def test_parses_django(self):
+class ExtractDjangoTestCase(unittest.TestCase):
+    # TODO: translator comments are not yet supported!
+
+    def test_extract_no_tags(self):
+        buf = BytesIO(b'nothing')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([], messages)
+
+    def test_extract_simple_double_quotes(self):
         buf = BytesIO(b'{% trans "Bunny" %}')
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == ([(1, None, u'Bunny', [])])
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'Bunny', [])], messages)
 
-    def test_parses_blocktrans(self):
-        buf = BytesIO(b'Ignored {% blocktrans %}{{ anton }}{% endblocktrans %}')
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == [(1, None, u'%(anton)s', [])]
+    def test_extract_simple_single_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'Bunny', [])], messages)
 
-    def test_parses_underscore(self):
-        buf = BytesIO(b'hello: <%= name %>')
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == []
+    def test_extract_simple_with_context_single_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' context 'carrot' %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, 'pgettext',
+                           [u'carrot', u'Bunny'], [])], messages)
 
-    def test_parses_underscore_gettext(self):
-        buf = BytesIO(b'hello: <%= gettext("name") %>')
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == [(1, 'gettext', u'name', [])]
+    def test_extract_simple_with_context_double_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' context \"carrot\" %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, 'pgettext',
+                           [u'carrot', u'Bunny'], [])], messages)
+
+    def test_extract_simple_with_context_with_single_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' context \"'carrot'\" %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, 'pgettext',
+                           [u'\'carrot\'', u'Bunny'], [])], messages)
+
+    def test_extract_simple_with_context_with_double_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' context '\"carrot\"' %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, 'pgettext',
+                           [u'"carrot"', u'Bunny'], [])], messages)
+
+    def test_extract_var(self):
+        buf = BytesIO(b'{% blocktrans %}{{ anton }}{% endblocktrans %}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'%(anton)s', [])], messages)
+
+    def test_extract_filter_with_filter(self):
+        test_tmpl = (
+            b'{% blocktrans with berta=anton|lower %}'
+            b'{{ berta }}{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'%(berta)s', [])], messages)
+
+    def test_extract_with_interpolation(self):
+        buf = BytesIO(b'{% blocktrans %}xxx{{ anton }}xxx{% endblocktrans %}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'xxx%(anton)sxxx', [])], messages)
 
     def test_extract_unicode(self):
-        buf = BytesIO(u'<%= gettext("@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ") %>'.encode('utf-8'))
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == [(1, 'gettext', u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])]
+        buf = BytesIO(u'{% trans "@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ" %}'.encode('utf8'))
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])], messages)
+
+    def test_extract_unicode_blocktrans(self):
+        test_tmpl = u'{% blocktrans %}@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ{% endblocktrans %}'
+        buf = BytesIO(test_tmpl.encode('utf8'))
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'@ſðæ314“ſſ¶ÐĐÞ→SÆ^ĸŁ', [])], messages)
+
+    # TODO: Yet expected to not extract the comments.
+    def test_extract_ignored_comment(self):
+        buf = BytesIO(
+            b'{# ignored comment #1 #}{% trans "Translatable literal #9a" %}',
+        )
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, None, u'Translatable literal #9a', [])], messages
+        )
+
+    def test_extract_ignored_comment2(self):
+        test_tmpl = (
+            b'{# Translators: ignored i18n comment #1 #}'
+            b'{% trans "Translatable literal #9a" %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, None, u'Translatable literal #9a', [])], messages
+        )
+
+    def test_extract_valid_comment(self):
+        test_tmpl = (
+            b'{# ignored comment #6 #}'
+            b'{% trans "Translatable literal #9h" %}'
+            b'{# Translators: valid i18n comment #7 #}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, None, u'Translatable literal #9h', [])], messages
+        )
 
     def test_extract_singular_form(self):
-        buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", 42) %>')
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None), [])]  # noqa
+        test_tmpl = (
+            b'{% blocktrans count counter=number %}'
+            b'singular{% plural %}{{ counter }} plural'
+            b'{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, 'ngettext', (u'singular', u'%(counter)s plural'), [])],
+            messages
+        )
 
-    def test_extract_singular_form_kwargs(self):
-        buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", count=42) %>')
-        messages = list(extract(buf, self.keywords, [], {}))
-        assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None, None), [])]  # noqa
+    def test_trans_blocks_must_not_include_other_block_tags(self):
+        buf = BytesIO(b'{% blocktrans %}{% other_tag %}{% endblocktrans %}')
+        gen = extract_django(buf, default_keys, [], {})
+        with pytest.raises(SyntaxError):
+            next(gen)
+
+    def test_extract_var_other(self):
+        buf = BytesIO(b'{{ book }}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([], messages)
+
+    def test_extract_filters_default_translatable(self):
+        buf = BytesIO(b'{{ book.author|default:_("Unknown") }}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'Unknown', [])], messages)
+
+    def test_extract_filters_default_translatable_single_quotes(self):
+        buf = BytesIO(b"{{ book.author|default:_('Unknown') }}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'Unknown', [])], messages)
+
+    def test_extract_constant_single_quotes(self):
+        buf = BytesIO(b"{{ _('constant') }}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'constant', [])], messages)
+
+    def test_extract_constant_double_quotes(self):
+        buf = BytesIO(b'{{ _("constant") }}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'constant', [])], messages)
+
+    def test_extract_constant_block(self):
+        buf = BytesIO(b'{% _("constant") %}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'constant', [])], messages)
+
+    def test_extract_constant_in_block(self):
+        test_tmpl = (
+            b'{% blocktrans foo=_("constant") %}{{ foo }}{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, None, u'constant', []), (1, None, u'%(foo)s', [])],
+            messages,
+        )
+
+    def test_extract_context_in_block(self):
+        test_tmpl = (
+            b'{% blocktrans context "banana" %}{{ foo }}{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, 'pgettext', [u'banana', u'%(foo)s'], [])],
+            messages,
+        )
+
+    def test_extract_context_in_plural_block(self):
+        test_tmpl = (
+            b'{% blocktrans context "banana" %}{{ foo }}'
+            b'{% plural %}{{ bar }}{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual(
+            [(1, 'npgettext', [u'banana', u'%(foo)s', u'%(bar)s'], [])],
+            messages,
+        )
+
+    def test_blocktrans_with_whitespace_not_trimmed(self):
+        test_tmpl = (
+            b'{% blocktrans %}\n\tfoo\n\tbar\n{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(4, None, u'\n\tfoo\n\tbar\n', [])], messages)
+
+    @pytest.mark.skipif(django.VERSION < (1, 7),
+                        reason='Trimmed whitespace is a Django >= 1.7 feature')
+    def test_blocktrans_with_whitespace_trimmed(self):
+        test_tmpl = (
+            b'{% blocktrans trimmed %}\n\tfoo\n\tbar\n{% endblocktrans %}'
+        )
+        buf = BytesIO(test_tmpl)
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(4, None, u'foo bar', [])], messages)


### PR DESCRIPTION
Part1: Using enmerkar instead of commit hash. Use this hash in platform.

Using enmerkar latest release.
Existing 4 tests were failing debugging them now. 
Tests with 
```
<%= gettext(
``` 
and 
```
<%= _(
``` 
failing